### PR TITLE
FEAT: making Objects global only

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-namespace */
-import type zzzzz from './objects';
+import type objectsObj from './objects';
 
 declare global
 {
     // this is required
     // eslint-disable-next-line no-var
-    var Objects: typeof zzzzz | undefined;
+    var Objects: typeof objectsObj;
 }
 
 export {  };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@
 /** -----------------------------------------------  */
 // (and sum data for using)
 
-import Objects from './objects';
 import makeGlobal from './unsafe/makeGlobal';
 
 /** @description Are we running in Node? */
@@ -16,12 +15,10 @@ let isNode: boolean = true;
 if(typeof window !== 'undefined' && typeof process !== 'object')
     isNode = false;
 
+
+// call makeGlobal initally.
+makeGlobal();
 export
 {
-    isNode,
-    Objects,
-    makeGlobal
+    isNode
 };
-
-
-export default Objects;

--- a/src/unsafe/makeGlobal.ts
+++ b/src/unsafe/makeGlobal.ts
@@ -1,4 +1,4 @@
-import obj from '../';
+import obj from '../objects';
 import { isNode } from '../';
 
 declare let window: any;
@@ -6,6 +6,7 @@ declare let window: any;
 /** @description Makes the Objects variable globally available. */
 const makeGlobal = (): void =>
 {
+    console.log('called #makeGlobal');
     if(isNode)
     {
         if(!global)

--- a/tests/Objects.test.ts
+++ b/tests/Objects.test.ts
@@ -1,4 +1,13 @@
-import Objects from '../src';
+import '../src';
+
+// this is required due to us not actually having the package installed.
+import type AObjects from '../src/objects';
+declare global
+{
+    // this is required
+    // eslint-disable-next-line no-var
+    var Objects: typeof AObjects;
+}
 
 describe('objects tests', () =>
 {

--- a/tests/Unsafe.test.ts
+++ b/tests/Unsafe.test.ts
@@ -1,19 +1,15 @@
-import type AObjects from '../src';
-import { makeGlobal } from '../src';
-
+import '../src';
+import type AObjects from '../src/objects';
 
 declare global
 {
     // this is required
     // eslint-disable-next-line no-var
-    var Objects: undefined | typeof AObjects;
+    var Objects: typeof AObjects;
 }
-
-export { };
 
 describe('unsafe func', () =>
 {
-    beforeAll(() => makeGlobal());
     it('can be accessed globally after called', () => expect(Objects).toBeDefined());
     // VSCode is weird here : it thinks that Objects can't be undefined, even though the type
     // says it can be. ! DO NOT REMOVE THE BANG.


### PR DESCRIPTION
makes the `Objects` object only accessible on the global field. IE: `window.Objects`, `global.Objects`